### PR TITLE
Update map styles

### DIFF
--- a/src/components/Map.jsx
+++ b/src/components/Map.jsx
@@ -71,12 +71,12 @@ function Map() {
         return (
           <Source id={layerId} type="geojson" data={layer} key={layerId}>
             <Layer
-              id="fill-layer"
+              id={`fill-layer-${layerId}`}
               type="fill"
               paint={{ "fill-color": "#1857e0", "fill-opacity": 0.25 }}
             />
             <Layer
-              id="line-layer"
+              id={`line-layer-${layerId}`}
               type="line"
               paint={{ "line-color": "#1857e0", "line-width": 2 }}
             />

--- a/src/components/Map.jsx
+++ b/src/components/Map.jsx
@@ -1,5 +1,9 @@
 import "maplibre-gl/dist/maplibre-gl.css";
-import MapGl, { Layer, Source, AttributionControl } from "react-map-gl/maplibre";
+import MapGl, {
+  Layer,
+  Source,
+  AttributionControl,
+} from "react-map-gl/maplibre";
 import { useEffect } from "react";
 import bbox from "@turf/bbox";
 import { mapLayersAtom } from "../atoms";
@@ -19,19 +23,28 @@ function Map() {
   // each layer is a feature collection, so we need to calculate the bounds of all features
   useEffect(() => {
     if (mapLayers.length > 0) {
-      const bounds = mapLayers.reduce((acc, layer) => {
-        const layerBounds = bbox(layer);
-        return [
-          Math.min(acc[0], layerBounds[0]),
-          Math.min(acc[1], layerBounds[1]),
-          Math.max(acc[2], layerBounds[2]),
-          Math.max(acc[3], layerBounds[3])
-        ];
-      }, [Infinity, Infinity, -Infinity, -Infinity]);
+      const bounds = mapLayers.reduce(
+        (acc, layer) => {
+          const layerBounds = bbox(layer);
+          return [
+            Math.min(acc[0], layerBounds[0]),
+            Math.min(acc[1], layerBounds[1]),
+            Math.max(acc[2], layerBounds[2]),
+            Math.max(acc[3], layerBounds[3]),
+          ];
+        },
+        [Infinity, Infinity, -Infinity, -Infinity]
+      );
 
-      mapRef.current.fitBounds([[bounds[0], bounds[1]], [bounds[2], bounds[3]]], {
-        padding: {top: 100, bottom: 100, left: 450, right: 100}
-      });
+      mapRef.current.fitBounds(
+        [
+          [bounds[0], bounds[1]],
+          [bounds[2], bounds[3]],
+        ],
+        {
+          padding: { top: 100, bottom: 100, left: 450, right: 100 },
+        }
+      );
     }
   }, [mapLayers]);
 
@@ -48,19 +61,28 @@ function Map() {
       <Source
         id="background"
         type="raster"
-        tiles={["https://tile.openstreetmap.org/{z}/{x}/{y}.png"]}
+        tiles={["https://api.mapbox.com/styles/v1/devseed/cm4sj2dh6005b01s80c8t623r/tiles/{z}/{x}/{y}?access_token=pk.eyJ1IjoiZGV2c2VlZCIsImEiOiJnUi1mbkVvIn0.018aLhX0Mb0tdtaT2QNe2Q"]}
         tileSize={256}
       >
         <Layer id="background-tiles" type="raster" />
       </Source>
-        {mapLayers.map((layer, idx) => {
-          const layerId = layer?.features[0]?.id || idx;
-          return (
-            <Source id={layerId} type="geojson" data={layer} key={layerId}>
-              <Layer id={layerId} type="line" paint={{ "line-color": "#ff0000", "line-width": 2 }} />
-            </Source>
-          );
-        })}
+      {mapLayers.map((layer, idx) => {
+        const layerId = layer?.features[0]?.id || idx;
+        return (
+          <Source id={layerId} type="geojson" data={layer} key={layerId}>
+            <Layer
+              id="fill-layer"
+              type="fill"
+              paint={{ "fill-color": "#1857e0", "fill-opacity": 0.25 }}
+            />
+            <Layer
+              id="line-layer"
+              type="line"
+              paint={{ "line-color": "#1857e0", "line-width": 2 }}
+            />
+          </Source>
+        );
+      })}
       <AttributionControl customAttribution="Background tiles: © <a href='https://www.openstreetmap.org/copyright'>OpenStreetMap contributors</a>" />
     </MapGl>
   );

--- a/src/components/Map.jsx
+++ b/src/components/Map.jsx
@@ -42,7 +42,7 @@ function Map() {
           [bounds[2], bounds[3]],
         ],
         {
-          padding: { top: 100, bottom: 100, left: 450, right: 100 },
+          padding: 100,
         }
       );
     }

--- a/src/components/MiniMap.jsx
+++ b/src/components/MiniMap.jsx
@@ -4,7 +4,7 @@ import "maplibre-gl/dist/maplibre-gl.css";
 import bbox from "@turf/bbox";
 
 /**
- * MiniMap is a static map for the sidebar 
+ * MiniMap is a static map for the sidebar
  */
 function MiniMap({ artifact }){
   let viewState = {
@@ -34,7 +34,7 @@ function MiniMap({ artifact }){
       <Source
         id="background"
         type="raster"
-        tiles={["https://tile.openstreetmap.org/{z}/{x}/{y}.png"]}
+        tiles={["https://api.mapbox.com/styles/v1/devseed/cm4sj2dh6005b01s80c8t623r/tiles/{z}/{x}/{y}?access_token=pk.eyJ1IjoiZGV2c2VlZCIsImEiOiJnUi1mbkVvIn0.018aLhX0Mb0tdtaT2QNe2Q"]}
         tileSize={256}
       >
         <Layer id="background-tiles" type="raster" />
@@ -45,7 +45,16 @@ function MiniMap({ artifact }){
           type="geojson"
           data={artifact}
         >
-          <Layer id="artifact-layer" type="line" paint={{ "line-color": "#ff0000", "line-width": 2 }} />
+          <Layer
+            id="fill-layer"
+            type="fill"
+            paint={{ "fill-color": "#1857e0", "fill-opacity": 0.25 }}
+          />
+          <Layer
+            id="line-layer"
+            type="line"
+            paint={{ "line-color": "#1857e0", "line-width": 2 }}
+          />
         </Source>
       )}
       <AttributionControl customAttribution="OSM contributors" />


### PR DESCRIPTION
Adds map styles to the current styling branch:
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/3e7c6587-e799-48d2-9259-59d0818bf707" />

Also updates the geojson selection style (red to blue)
[See map style at preview URL](https://api.mapbox.com/styles/v1/devseed/cm4sj2dh6005b01s80c8t623r.html?title=view&access_token=pk.eyJ1IjoiZGV2c2VlZCIsImEiOiJnUi1mbkVvIn0.018aLhX0Mb0tdtaT2QNe2Q&zoomwheel=true&fresh=true#2.69/-1.48/-67.88)