### PR TITLE
Add .env.production

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,1 @@
+VITE_MOCK_QUERIES=false


### PR DESCRIPTION
MSW doesn’t offer a way to configure the path from where we load the mock service worker. The only alternative would be to deploy this to an S3 bucket and and run the app from a CloudFront CDN, so we can run it in the root directory.  

So I added a production env (.env.production), which turns of the service worker in production builds.