### PR TITLE
Resize chart with ResizeObserver

### DIFF
--- a/src/components/ChatOutput.jsx
+++ b/src/components/ChatOutput.jsx
@@ -28,7 +28,6 @@ function ChatOutput() {
         observer.disconnect();
       };
     }
-
   }, []);
 
   return (


### PR DESCRIPTION
Uses `ResizeObserver` to set the chart dimensions to the parent container. We're storing the dimensions in state, which allows use to render the chart after the parent component dimensions have been read. 
