### PR TITLE
Add navigation and scale controls to map

### DIFF
--- a/src/components/Map.jsx
+++ b/src/components/Map.jsx
@@ -3,6 +3,8 @@ import MapGl, {
   Layer,
   Source,
   AttributionControl,
+  NavigationControl,
+  ScaleControl
 } from "react-map-gl/maplibre";
 import { config } from "../theme";
 import { useEffect, useState, useRef } from "react";
@@ -129,6 +131,8 @@ function Map() {
           );
         })};
       <AttributionControl customAttribution="Background tiles: © <a href='https://www.openstreetmap.org/copyright'>OpenStreetMap contributors</a>" />
+      <ScaleControl />
+      <NavigationControl showCompass={false} position="bottom-left" />
     </MapGl>
   );
 }


### PR DESCRIPTION
Adds simple maplibre map controls to map - navigation (zoom), and scale.
![image](https://github.com/user-attachments/assets/af5b76c6-b31a-4953-b58d-9db459ca3889)

Contributes to https://github.com/wri/project-zeno/issues/72