### PR TITLE
Auto-open widget panel

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,5 +47,6 @@
     "workerDirectory": [
       "public"
     ]
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/src/atoms.js
+++ b/src/atoms.js
@@ -10,7 +10,7 @@ export const isLoadingAtom = atom(false);
 export const chartDataAtom = atom();
 export const layerVisibilityAtom = atom({});
 export const interruptedStateAtom = atom(false); // when we receive an interrupt from the API
-export const dataPaneOpenAtom = atom(false);
+export const dataPaneTabAtom = atom("");
 export const recentImageryAtom = atom([]);
 
 function makeInputMessage(query) {
@@ -90,7 +90,7 @@ export const addPrompt = atom(null, (get, set, promt) => {
 
 /**
  * Adds a new layer to the map
- * 
+ *
  */
 export const addLayerAtom = atom(
   null, // No initial value for a write-only atom

--- a/src/components/BarChart.jsx
+++ b/src/components/BarChart.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import * as d3 from "d3";
-import { dataPaneOpenAtom, chartDataAtom } from "../atoms";
+import { chartDataAtom, dataPaneTabAtom } from "../atoms";
 import { useAtomValue } from "jotai";
 
 const BarChart = () => {
@@ -9,11 +9,12 @@ const BarChart = () => {
   const tooltipRef = useRef();
 
   const [ chartDimensions, setChartDimensions ] = useState([0, 0]);
-  const dataPaneOpen = useAtomValue(dataPaneOpenAtom);
+  // const dataPaneOpen = useAtomValue(dataPaneOpenAtom);
+  const dataPaneTab = useAtomValue(dataPaneTabAtom);
   const data = useAtomValue(chartDataAtom);
 
   useEffect(() => {
-    if (dataPaneOpen && containerRef.current) {
+    if (dataPaneTab && containerRef.current) {
       const observer = new ResizeObserver(entries => {
         const e = entries[0];
         const parentElement = e.target.parentElement;
@@ -28,7 +29,7 @@ const BarChart = () => {
         observer.disconnect();
       };
     }
-  }, [dataPaneOpen]);
+  }, [dataPaneTab]);
 
   useEffect(() => {
     // Exit effect if at least one dimesion is 0

--- a/src/components/MessageOut/MessageTool.jsx
+++ b/src/components/MessageOut/MessageTool.jsx
@@ -3,7 +3,13 @@ import MessageOutWrapper from "./wrapper";
 
 import { useEffect } from "react";
 import { useSetAtom } from "jotai";
-import { chartDataAtom, addLayerAtom, confirmedLocationAtom, recentImageryAtom } from "../../atoms";
+import {
+  chartDataAtom,
+  dataPaneTabAtom,
+  addLayerAtom,
+  confirmedLocationAtom,
+  recentImageryAtom
+} from "../../atoms";
 
 function ContextLayer({ message, artifact }) {
   const addLayer = useSetAtom(addLayerAtom);
@@ -86,6 +92,7 @@ function DistAlertsTool({ message, artifact }) {
 
   const addLayer = useSetAtom(addLayerAtom);
   const setChartData = useSetAtom(chartDataAtom);
+  const setDataPaneTab = useSetAtom(dataPaneTabAtom);
 
   useEffect(() => {
     const json = JSON.parse(message);
@@ -104,10 +111,11 @@ function DistAlertsTool({ message, artifact }) {
 
 
       if (numDisturbances > 0) {
-        addLayer(layer); 
+        addLayer(layer);
         setChartData(data);
+        setDataPaneTab("chart");
       }
-  }, [message, addLayer, artifact, setChartData]);
+  }, [message, addLayer, artifact, setChartData, setDataPaneTab]);
 
   const json = JSON.parse(message);
   const numDisturbances = Object.keys(json).length;
@@ -131,14 +139,17 @@ DistAlertsTool.propTypes = {
 
 /**
  * Takes in a STAC message for recent satellite imagery
- * 
+ *
  */
 function StacTool({ message }) {
   const recentImageryArray = JSON.parse(message);
   const setRecentImagery = useSetAtom(recentImageryAtom);
+  const setDataPaneTab = useSetAtom(dataPaneTabAtom);
+
   let render = <div>No Recent Imagery</div>;
   if (recentImageryArray.length > 0) {
     setRecentImagery(recentImageryArray);
+    setDataPaneTab("imagery");
     render = <div>Added Recent Imagery to Data Pane</div>;
   }
 

--- a/src/components/TabbedPanel.jsx
+++ b/src/components/TabbedPanel.jsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import T from "prop-types";
 import { Tabs, Flex, Heading } from "@chakra-ui/react";
 import {
@@ -6,13 +7,19 @@ import {
   AccordionItemTrigger,
   AccordionRoot,
 } from "./ui/accordion";
-import { dataPaneOpenAtom } from "../atoms";
+import { dataPaneTabAtom } from "../atoms";
 import { useAtom } from "jotai";
 
 const panelHeight = "20rem";
 
 function TabbedPanel({ tabData }) {
-  const [, setDataPaneOpen] = useAtom(dataPaneOpenAtom);
+  const [dataPaneTab, setDataPaneTab] = useAtom(dataPaneTabAtom);
+  const [isOpen, setIsOpen] = useState(true);
+
+  useEffect(() => {
+    setIsOpen(!!dataPaneTab);
+  }, [dataPaneTab]);
+
   if (!tabData) return;
   return (
     <AccordionRoot
@@ -24,9 +31,10 @@ function TabbedPanel({ tabData }) {
       shadow="md"
       overflow="auto"
       maxH={panelHeight}
-      onValueChange={(isOpen) => setDataPaneOpen(isOpen)}
+      value={isOpen ? ["widget-list"] : []}
+      onValueChange={({ value }) => setIsOpen(value.length !== 0)}
     >
-      <Tabs.Root lazyMount unmountOnExit defaultValue="tab-1" variant="line">
+      <Tabs.Root lazyMount unmountOnExit value={dataPaneTab} onValueChange={(e) => setDataPaneTab(e.value)} variant="line">
         <AccordionItem
           css={{
             "&[data-scope=\"accordion\"][data-state=\"closed\"]  [data-scope=\"tabs\"]":
@@ -34,6 +42,7 @@ function TabbedPanel({ tabData }) {
             "&[data-scope=\"accordion\"][data-state=\"closed\"] [data-scope=\"tabs\"][aria-selected=true][data-selected][data-orientation=horizontal]":
               {"--indicator-color": "transparent" },
           }}
+          value="widget-list"
         >
           <Flex>
             <Tabs.List flex="1">


### PR DESCRIPTION
Automatically open the widget panel when chart data or images are added. 

I've added a new state `dataPaneTabAtom` which holds a string of the current open tab. Opening/closing the panel list handled with an internal state in `TabbedPanel` and an effect hook, which is triggered whenever the value of `dataPaneTabAtom` changes. 