### PR TITLE
Add thousands/millions formatting to BarChart y-axis

### DIFF
--- a/src/components/BarChart.jsx
+++ b/src/components/BarChart.jsx
@@ -25,6 +25,7 @@ const BarChart = () => {
         colors[description] = color_hexcode;
       });
       setColorMapping(colors);
+    // eslint-disable-next-line no-unused-vars
     } catch (e) {
       // do nothing
     }

--- a/src/components/BarChart.jsx
+++ b/src/components/BarChart.jsx
@@ -13,7 +13,6 @@ const BarChart = () => {
   // const dataPaneOpen = useAtomValue(dataPaneOpenAtom);
   const dataPaneTab = useAtomValue(dataPaneTabAtom);
   const data = useAtomValue(chartDataAtom);
-
   const mapLayers = useAtomValue(mapLayersAtom);
 
   useEffect(() => {
@@ -26,12 +25,10 @@ const BarChart = () => {
         colors[description] = color_hexcode;
       });
       setColorMapping(colors);
-    // eslint-disable-next-line no-unused-vars
     } catch (e) {
       // do nothing
     }
   }, [mapLayers]);
-
 
   useEffect(() => {
     if (dataPaneTab && containerRef.current) {
@@ -52,9 +49,17 @@ const BarChart = () => {
   }, [dataPaneTab]);
 
   useEffect(() => {
-    // Exit effect if at least one dimesion is 0
-    if (!chartDimensions.every(x => !!x)) return;
-    if (!data) return;
+    // Exit effect if at least one dimension is 0
+    if (!chartDimensions.every((x) => !!x) || !data) return;
+
+    const getScaleAndLabel = (maxValue) => {
+      if (maxValue >= 1e6) return { scale: 1e6, label: "millions" };
+      if (maxValue >= 1e3) return { scale: 1e3, label: "thousands" };
+      return { scale: 1, label: "count" };
+    };
+
+    const maxValue = d3.max(data, d => d.value);
+    const { scale, label } = getScaleAndLabel(maxValue);
 
     const svg = d3.select(chartRef.current);
     svg.selectAll("*").remove();
@@ -71,7 +76,7 @@ const BarChart = () => {
       .padding(0.1);
 
     const y = d3.scaleLinear()
-      .domain([0, d3.max(data, d => d.value)])
+      .domain([0, maxValue / scale])
       .nice()
       .range([height - margin.bottom, margin.top]);
 
@@ -101,8 +106,7 @@ const BarChart = () => {
       .attr("dy", "1em")
       .style("text-anchor", "middle")
       .style("font-size", "12px")
-      .text("alerts (count)");
-
+      .text(`alerts (${label})`);
 
     // Add bars
     svg.append("g")
@@ -110,8 +114,8 @@ const BarChart = () => {
       .data(data)
       .enter().append("rect")
       .attr("x", d => x(d.category))
-      .attr("y", d => y(d.value))
-      .attr("height", d => y(0) - y(d.value))
+      .attr("y", d => y(d.value / scale))
+      .attr("height", d => y(0) - y(d.value / scale))
       .attr("width", x.bandwidth())
       .attr("fill", d => colorMapping[d.category] || "steelblue")
       .on("mouseover", (event, d) => {

--- a/src/components/MessageOut/MessageTool.jsx
+++ b/src/components/MessageOut/MessageTool.jsx
@@ -2,6 +2,7 @@ import T from "prop-types";
 import MessageOutWrapper from "./wrapper";
 
 import { useEffect, useState } from "react";
+import { Alert }  from "../ui/alert";
 import { useSetAtom } from "jotai";
 import {
   chartDataAtom,
@@ -92,6 +93,7 @@ function DistAlertsTool({ message, artifact }) {
   const setDataPaneTab = useSetAtom(dataPaneTabAtom);
 
   useEffect(() => {
+    try {
     const json = JSON.parse(message);
     const numDisturbances = Object.keys(json).length;
       const data = Object.entries(json).map(([category, value]) => ({
@@ -112,19 +114,33 @@ function DistAlertsTool({ message, artifact }) {
         setChartData(data);
         setDataPaneTab("chart");
       }
+
+    } catch (e) {
+      console.error("Failed to parse message", e);
+    }
   }, [message, addLayer, artifact, setChartData, setDataPaneTab]);
 
-  const json = JSON.parse(message);
-  const numDisturbances = Object.keys(json).length;
+  try {
+    const json = JSON.parse(message);
+    const numDisturbances = Object.keys(json).length;
 
-  if (numDisturbances > 0) {
+    if (numDisturbances > 0) {
+      return (
+        <>Adding alerts to the map.</>
+      );
+    }
+    else {
+      return (
+        <>No alerts found.</>
+      );
+    }
+
+  // eslint-disable-next-line no-unused-vars
+  } catch (e) {
     return (
-      <>Adding alerts to the map.</>
-    );
-  }
-  else {
-    return (
-      <>No alerts found.</>
+      <Alert status="error" title="Error">
+        There was a problem processing your request. Please try again or try another prompt;
+      </Alert>
     );
   }
 }


### PR DESCRIPTION
## Summary
Adds formatting to BarChart component, scales alert count label, axis title and bars by thousand or millions as appropriate in order to avoid text overflow.

<img width="1199" alt="Screenshot 2025-01-28 at 11 31 01" src="https://github.com/user-attachments/assets/0a0a101d-9c89-45c9-9dcf-d95871d78fe5" />

To test, try:

- (count) `Show me alerts in San Ignacio de Velasco, Santa Cruz in Bolivia in the last 2 weeks and group by grassland type`
- (thousands) `Show me alerts in San Ignacio de Velasco, Santa Cruz in Bolivia in Aug 2024 and group by grassland type`
- (millions) `Show me alerts in San Ignacio de Velasco, Santa Cruz in Bolivia in 2024 and group by grassland type`