### PR TITLE
Suggested Location disambiguation

### DIFF
--- a/src/components/MessageOut/HumanInput.jsx
+++ b/src/components/MessageOut/HumanInput.jsx
@@ -23,7 +23,7 @@ function HumanInput({ options }) {
     <MessageOutWrapper>
       Select a location:
       <List.Root listStyle="none" pl="0" display="flex" flexDir="row" flexWrap="wrap" gap="2">
-        {options.map((option) => {
+        {options.map((option, i) => {
 
           let gid = option[1];
           let name = option[0];
@@ -38,7 +38,7 @@ function HumanInput({ options }) {
                 onMouseEnter={() => setHighlightedLocation(gid)}
                 onMouseLeave={() => setHighlightedLocation(null)}
               >
-                {name}
+                {i+1}. {name}
               </QueryButton>
             </List.Item>
           );

--- a/src/components/MessageOut/MessageTool.jsx
+++ b/src/components/MessageOut/MessageTool.jsx
@@ -67,14 +67,19 @@ function LocationTool({ artifact }) {
   if (numLocations === 0) {
     return <p>No locations found.</p>;
   }
+
   return (
     <>
       <p>Found {numLocations} Locations:</p>
-      <ul>
-        {artifact?.map((f) => (
-          <li key={f.id}>{f.properties.name}</li>
-        ))}
-      </ul>
+      <ol>
+        {artifact?.map((f) => {
+          const regionName = f.properties?.mapbox_context?.region?.name
+          const adminLevel = f.properties?.admin_level ? ` (${f.properties.admin_level})` : ""
+          const locationName = f.properties.name
+          // dont show repeated region name if it is the same as location name and use admin level to disambiguate
+          return <li key={f.id}>{regionName && locationName !== regionName ? `${locationName}, ${regionName}` : `${locationName}${adminLevel}`}</li>
+        })}
+      </ol>
     </>
   );
 }

--- a/src/theme/globalCss.jsx
+++ b/src/theme/globalCss.jsx
@@ -14,6 +14,12 @@ export default {
     listStyleType: "disc",
     paddingLeft: 4
   },
+  ol: {
+    marginTop: 4,
+    marginBottom: 4,
+    listStyleType: "decimal",
+    paddingLeft: 4,
+  },
   p: {
     marginTop: 4,
     marginBottom: 4,


### PR DESCRIPTION
# Summary
Update LocationTool to use information returned by the api to disambiguate locations with the same name. These small changes should help users better understand which location each button refers to.

- Adds a unique region name, where available
- If region name is the same as the location name, adds an Admin level
- Uses a numbered list to associate the `confirmLocation` button with locations returned by Zeno.

Before
![image](https://github.com/user-attachments/assets/04a00369-37dd-4ca8-8b37-62e9538f9b49)

After
![image](https://github.com/user-attachments/assets/e1df810b-4ec9-434b-9f87-3238bdd251db)
