### PR TITLE
Filmstrip human readable date

### DIFF
--- a/src/components/FilmStrip.jsx
+++ b/src/components/FilmStrip.jsx
@@ -31,10 +31,12 @@ function ImageItem({ id }) {
       const year = dateStr.slice(0, 4); // YYYY
       const month = dateStr.slice(4, 6); // MM
       const day = dateStr.slice(6, 8); // DD
+      const instrument = str.split("_")[0]; // e.g., 'S2A'
+      const instrumentSring = instrument === 'S2A' || instrument === 'S2B' ? `(${instrument}) ` : ''
   
       // Create a Date object and format it
       const date = new Date(`${year}-${month}-${day}`);
-      return date.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' }); // e.g., "August 27, 2023"
+      return instrumentSring + date.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' }); // e.g., "August 27, 2023"
     }
     return str; // Return original id match is found
   };

--- a/src/components/FilmStrip.jsx
+++ b/src/components/FilmStrip.jsx
@@ -23,6 +23,21 @@ function ImageItem({ id }) {
     "url": `${titiler(id)}`,
     "name": "Sentinel-2",
   };
+  const parseDateFromId = (str) => {
+    // Extract the date from the STAC id (YYYYMMDD) using a regex
+    const match = str.match(/\d{8}/);
+    if (match) {
+      const dateStr = match[0]; // e.g., '20230827'
+      const year = dateStr.slice(0, 4); // YYYY
+      const month = dateStr.slice(4, 6); // MM
+      const day = dateStr.slice(6, 8); // DD
+  
+      // Create a Date object and format it
+      const date = new Date(`${year}-${month}-${day}`);
+      return date.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' }); // e.g., "August 27, 2023"
+    }
+    return str; // Return original id match is found
+  };
   return (
     <Card.Root borderRadius="lg" overflow="hidden" width="12rem" height="8rem" role="button">
       <LinkOverlay onClick={() => addLayer(layer)} cursor="pointer">
@@ -40,7 +55,7 @@ function ImageItem({ id }) {
         left={0}
       >
         <Card.Title left={2} pos="relative" color="white" fontSize="sm">
-          {id}
+          {parseDateFromId(id)}
         </Card.Title>
       </Box>
       </LinkOverlay>


### PR DESCRIPTION
## Summary
Adds human readable labels to `filmStrip` thumbnails, extracting date and instrument from the returned STAC id:

e.g. `'S2B_29TNF_20230827_0_L2A'`
returning `(instrument) Month DD, YYYY` e.g. `(S2B) August 27, 2023`

Should the string structure differ from expected, falls back on the id.

![Screenshot 2025-01-28 at 3 59 12 PM](https://github.com/user-attachments/assets/581e875a-8159-4829-bf5f-a7c77ab5592f)
