### PR TITLE
Add collapsible report sidebar [WIP]

### DIFF
--- a/src/routes/monitoring.jsx
+++ b/src/routes/monitoring.jsx
@@ -1,10 +1,17 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { Box, Grid } from "@chakra-ui/react";
+import { Box, Collapsible, Heading, Grid, Flex } from "@chakra-ui/react";
+import { useState } from "react";
 import Providers from "../Providers";
 import { ChatInput, ChatOutput } from "../components";
 import GlobalHeader from "../components/globalheader";
+import {
+  CollecticonClipboard,
+  CollecticonSpeechBalloon,
+} from "@devseed-ui/collecticons-react";
 
 function Monitoring() {
+  const [isOpen, setIsOpen] = useState(false);
+
   return (
     <Providers>
       <Grid
@@ -14,17 +21,35 @@ function Monitoring() {
         bg="gray.50"
       >
         <GlobalHeader />
-        <Grid templateColumns="28rem 1fr" p="6" gap="2">
+        <Grid templateColumns="1fr" templateRows="1fr" p="6" gap="2">
           <Grid
             gap="4"
-            templateRows="1fr max-content"
+            templateRows="max-content 1fr max-content"
             borderRadius="lg"
             shadow="md"
-            p="4"
+            px="4"
+            py="6"
             height="0"
             minH="100%"
             bgColor="white"
+            gridRow="1"
           >
+            <Box
+              m="-4"
+              display="flex"
+              gap="2"
+              alignItems="center"
+              h="fit-content"
+              px="4"
+              py="2"
+              border="1"
+              borderBottomWidth="1px"
+            >
+              <CollecticonSpeechBalloon size="24" />
+              <Heading size="sm" m="0">
+                Chat
+              </Heading>
+            </Box>
             <Box overflowY="auto" height="100%" mx="-4" px="4">
               <ChatOutput />
             </Box>
@@ -32,9 +57,50 @@ function Monitoring() {
               <ChatInput />
             </Box>
           </Grid>
-          <Grid templateRows="1fr" gap="2">
-            <Box borderRadius="lg" shadow="md" overflow="hidden" />
-          </Grid>
+          <Collapsible.Root
+            minH="100%"
+            bgColor="white"
+            p="4"
+            gridRow="1"
+            gridColumn="2"
+            borderRadius="lg"
+            shadow="md"
+            maxW="50vw"
+            isOpen={open}
+            onOpenChange={() => setIsOpen((prev) => !prev)}
+            display="flex"
+            flexDir="column"
+            gap="4"
+          >
+            <Collapsible.Trigger w="100%" cursor="pointer">
+              <Box
+                m="-4"
+                display="flex"
+                gap="2"
+                justifyContent="start"
+                alignItems="center"
+                px="4"
+                py="3"
+                border="1"
+                borderBottomWidth="1px"
+              >
+                <CollecticonClipboard size="24" />
+                {isOpen && (
+                  <Heading size="sm" m="0">
+                    Report
+                  </Heading>
+                )}
+              </Box>
+            </Collapsible.Trigger>
+            <Collapsible.Content>
+              <Box>
+                Lorem Ipsum is simply dummy text of the printing and typesetting
+                industry. Lorem Ipsum has been the industrys standard dummy text
+                ever since the 1500s, when an unknown printer took a galley of
+                type and scrambled it to make a type specimen book.
+              </Box>
+            </Collapsible.Content>
+          </Collapsible.Root>
         </Grid>
       </Grid>
     </Providers>


### PR DESCRIPTION
WIP - adding collapsible report sidepanel

https://github.com/user-attachments/assets/0a35027a-d532-41b0-8fe7-75c1b8dd29a4


TODO:
- [ ] Collapse chat panel when triggered
- [ ] Add separate state tracking for report & chat panel open states (explore using jotai)
- [ ] Change collapsible animation from height to width
- [ ] Ensure grid layout is set up to accommodate width animation

cc @kamicut 