### PR TITLE
Update/style nits

### DIFF
--- a/src/components/AudioButton.jsx
+++ b/src/components/AudioButton.jsx
@@ -40,12 +40,7 @@ const AudioPlayButton = ({ audioUrl }) => {
   return (
     <Button
       onClick={() => toggleAudio(audioUrl)}
-      style={{
-        background: "none",
-        border: "none",
-        cursor: "pointer",
-        color: "#007BFF",
-      }}
+      colorPalette="blue"
       title={isPlaying ? "Pause Sound" : "Play Sound"}
     >
       {isPlaying ? <MdStopCircle size={24} /> : <MdVolumeUp size={24} />}

--- a/src/components/BarChart.jsx
+++ b/src/components/BarChart.jsx
@@ -149,8 +149,8 @@ const BarChart = () => {
         ref={tooltipRef}
         style={{
           position: "absolute",
-          background: "rgba(0, 0, 0, 0.7)",
-          color: "white",
+          background: "var(--chakra-colors-bg)",
+          color: "var(--chakra-colors-fg)",
           padding: "5px",
           borderRadius: "4px",
           pointerEvents: "none", // Ensure it doesn't block mouse events

--- a/src/components/ChatInput.jsx
+++ b/src/components/ChatInput.jsx
@@ -38,7 +38,7 @@ function ChatInput() {
       <Button
         position="absolute"
         right="2"
-        bottom="0"
+        bottom="0.5"
         transform="translateY(-50%)"
         padding="0"
         {...(inputValue?.trim().length == 0 && { disabled: true })}

--- a/src/components/LayerSwitcher.jsx
+++ b/src/components/LayerSwitcher.jsx
@@ -36,7 +36,7 @@ function LayerSwitcher() {
       borderRadius="md"
       plain="true"
       collapsible
-      boxShadow="md"
+      boxShadow="sm"
       zIndex="1000"
       maxW="16rem"
     >

--- a/src/components/Map.jsx
+++ b/src/components/Map.jsx
@@ -241,7 +241,7 @@ function Map() {
           borderRadius={8}
           fontSize="10px"
           bg={useColorModeValue("whiteAlpha.600", "blackAlpha.600")}
-          boxShadow="md"
+          boxShadow="sm"
         >
           lat, lon: {mapCenter[1].toFixed(3)}, {mapCenter[0].toFixed(3)}
         </Code>

--- a/src/components/MessageOut/wrapper.jsx
+++ b/src/components/MessageOut/wrapper.jsx
@@ -4,13 +4,11 @@ import { LclLogo } from "..";
 
 function MessageOutWrapper({ children }) {
   return (
-    <Box display="flex" gap="2" alignItems="flex-start">
-      <Box bg="bg.subtle" px="11px" py="10px" borderRadius="full">
-        <LclLogo width="10" avatarOnly fill="var(--chakra-colors-bg-inverted)" />
+    <Box mb="4" p="2" bgColor="bg.muted" borderRadius="md" borderWidth={1} borderColor="border" flexGrow="1" overflow="hidden">
+      <Box float="left" mr="1" mt="0.5">
+        <LclLogo width="12" avatarOnly fill="var(--chakra-colors-bg-inverted)" float="left" />
       </Box>
-      <Box mb="4" p="2" bgColor="bg.subtle" borderRadius="md" flexGrow="1" shadow="md" flexGrow="1" overflow="hidden">
-        {children}
-      </Box>
+      {children}
     </Box>
   );
 }

--- a/src/components/ReportContentWidget.jsx
+++ b/src/components/ReportContentWidget.jsx
@@ -1,14 +1,14 @@
 // Report Widget for Monitoring App
 // Renders different Widgets Based on selected insights
 
-import { Box, IconButton } from "@chakra-ui/react";
+import { Box, Button } from "@chakra-ui/react";
 import TextWidget from "./insights/TextWidget";
 import TableWidget from "./insights/TableWidget";
 import ChartWidget from "./insights/BarChartWidget";
 import TimeSeriesWidget from "./insights/TimeSeriesWidget";
 import { deleteFromReportAtom } from "../atoms";
 import { useAtom } from "jotai";
-import { TiDelete } from "react-icons/ti";
+import { CollecticonTrashBin } from "@devseed-ui/collecticons-react";
 
 export default function ReportContentWidget(data) {
   const [, deleteFromReport] = useAtom(deleteFromReportAtom);
@@ -37,17 +37,32 @@ export default function ReportContentWidget(data) {
   }
 
   return (
-    <Box position="relative" gridColumn="2" gridRow="2 / -1" my="4" p="12" h="100%" borderRadius="lg" border="1px solid" borderColor="border" bg="bg.subtle" justifySelf="stretch" overflowY="scroll">
-      <IconButton
+    <Box
+      position="relative"
+      gridColumn="2"
+      gridRow="2 / -1"
+      mb="4"
+      p="12"
+      h="100%"
+      borderRadius="lg"
+      bg="bg"
+      border="1px solid"
+      borderColor="border"
+      justifySelf="stretch"
+      overflowY="scroll"
+    >
+      <Button
         position="absolute"
         top="10px"
         right="10px"
         aria-label="Remove from report"
-        size="sm"
+        size="xs"
+        variant="ghost"
         onClick={() => deleteFromReport(data.title)}
       >
-        <TiDelete />
-      </IconButton>
+        <CollecticonTrashBin />
+        Remove from report
+      </Button>
       <WidgetComponent {...data} />
     </Box>
   );

--- a/src/components/SidePanelWidget.jsx
+++ b/src/components/SidePanelWidget.jsx
@@ -46,15 +46,16 @@ export default function SidePanelWidget() {
         position="absolute"
         top="10px"
         right="10px"
+        size="xs"
       >
         {
           isInReport
-            ? <Button size="sm" colorScheme="red" onClick={() => deleteFromReport(sidePanelContent.title)}>Remove From Report</Button>
-            : <Button size="sm" onClick={() => addToReport(sidePanelContent)}>Add To Report</Button>
+            ? <Button colorPalette="red" textTransform="uppercase" variant="surface" onClick={() => deleteFromReport(sidePanelContent.title)}>Remove From Report</Button>
+            : <Button colorPalette="blue" textTransform="uppercase" variant="surface" onClick={() => addToReport(sidePanelContent)}>Add To Report</Button>
         }
         <IconButton
           aria-label="Close panel"
-          size="sm"
+          variant="ghost"
           onClick={() => setSidePanelContent(null)}
         >
           <CgClose />

--- a/src/components/globalheader.jsx
+++ b/src/components/globalheader.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { Link, useLocation } from "@tanstack/react-router";
-import { Box, Button, Flex, Image, Text } from "@chakra-ui/react";
+import { Box, Button, Flex, Text } from "@chakra-ui/react";
 import {
   MenuContent,
   MenuRadioItemGroup,
@@ -30,9 +30,8 @@ function GlobalHeader() {
 
   return (
     <Box
-      bg="bg.panel"
-      shadow="sm"
-      px="8"
+      px="6"
+      pr="8"
       py="4"
       display="flex"
       justifyContent="space-between"

--- a/src/components/insights/BarChartWidget.jsx
+++ b/src/components/insights/BarChartWidget.jsx
@@ -58,9 +58,9 @@ export default function ChartWidget({ data, title, description }) {
 
       const tooltip = d3.select(tooltipRef.current)
         .style("position", "absolute")
-        .style("background", "white")
+        .style("background", "var(--chakra-colors-bg)")
         .style("padding", "8px")
-        .style("border", "1px solid #ccc")
+        .style("border", "1px solid var(--chakra-colors-border)")
         .style("border-radius", "4px")
         .style("display", "none");
 
@@ -100,7 +100,7 @@ export default function ChartWidget({ data, title, description }) {
         .append("path")
         .attr("d", arc)
         .attr("fill", (d, i) => color(i))
-        .style("stroke", "#fff")
+        .style("stroke", "var(--chakra-colors-border-emphasized)")
         .style("stroke-width", "2px")
         .on("mouseover", (event, d) => {
           tooltip.style("visibility", "visible").text(`${d.data.name}: ${d.data.value}`);
@@ -117,13 +117,15 @@ export default function ChartWidget({ data, title, description }) {
   }, [data, chartType]);
 
   return (
-    <Box ref={containerRef} style={{ position: "relative" }}>
+    <Box ref={containerRef} style={{ position: "relative" }} padding="0">
       <Heading>{title}</Heading>
       <IconButton
         onClick={() => setChartType(chartType === "bar" ? "pie" : "bar")}
         aria-label="Toggle Chart Type"
-        m={2}
-        p={2}
+        mt={2}
+        px={2}
+        variant="surface"
+        size="xs"
       >
         Toggle {chartType === "bar" ? <FaChartPie /> : <FaChartBar />}
       </IconButton>

--- a/src/components/insights/TimeSeriesWidget.jsx
+++ b/src/components/insights/TimeSeriesWidget.jsx
@@ -58,9 +58,9 @@ export default function TimeSeriesWidget(data) {
     // Cursor, Tooltip, and Dashed Line
     const tooltip = d3.select(tooltipRef.current)
       .style("position", "absolute")
-      .style("background", "white")
+      .style("background", "var(--chakra-colors-bg)")
       .style("padding", "8px")
-      .style("border", "1px solid #ccc")
+      .style("border", "1px solid var(--chakra-colors-border)")
       .style("border-radius", "4px")
       .style("display", "none");
 

--- a/src/routes/alerting.jsx
+++ b/src/routes/alerting.jsx
@@ -49,13 +49,14 @@ function Alerting() {
       bg="bg"
     >
       <GlobalHeader />
-      <Grid templateColumns="28rem 1fr" p="6" gap="2">
+      <Grid templateColumns="28rem 1fr" p="4" pt="0" gap="2">
         <Grid
           gap="4"
           templateRows="1fr max-content"
           borderRadius="lg"
           shadow="md"
           p="4"
+          pb="2"
           height="0"
           minH="100%"
           bg={useColorModeValue("bg.panel", "bg.emphasized")}

--- a/src/routes/monitoring.jsx
+++ b/src/routes/monitoring.jsx
@@ -101,12 +101,12 @@ function Monitoring() {
               </Collapsible.Trigger>
               <Collapsible.Content>
                 <Box overflow={reportContent.length > 1 ? "auto" : "visible"} maxH="100%">
-                  <List.Root>
-                    <List.Item>
-                      {reportContent.map((data) => (
-                        <ReportContentWidget key={data.title} {...data} />
-                      ))}
-                    </List.Item>
+                  <List.Root listStyle="none" p="0" mt="4" mb="0">
+                    {reportContent.map((data) => (
+                      <List.Item key={data.title}>
+                        <ReportContentWidget {...data} />
+                      </List.Item>
+                    ))}
                   </List.Root>
                 </Box>
               </Collapsible.Content>

--- a/src/routes/monitoring.jsx
+++ b/src/routes/monitoring.jsx
@@ -23,7 +23,7 @@ function Monitoring() {
         bg="bg"
       >
         <GlobalHeader />
-        <Grid templateColumns="1fr" templateRows="1fr" p="6" gap="2">
+        <Grid templateColumns="1fr" templateRows="1fr" p="4" pt="0" gap="2">
           <Grid
             gap="4"
             templateRows="max-content 1fr max-content"
@@ -31,8 +31,7 @@ function Monitoring() {
             borderRadius="lg"
             shadow="md"
             justifyItems="center"
-            px="4"
-            py="6"
+            p="4"
             pb="2"
             height="0"
             minH="100%"
@@ -46,7 +45,7 @@ function Monitoring() {
               alignItems="center"
               h="fit-content"
               px="4"
-              py="2"
+              py="3"
               borderBottomWidth="1px"
               borderColor="border.emphasized"
               justifySelf="stretch"


### PR DESCRIPTION
Minor style changes to implement design suggestions from @faustoPerez, style report buttons, and address some other minor issues.

This PR:
- Inlines the LCL logo into the chat window
- Removes some padding from the header and overall widgets to give the map and insights greater screen real esttate
- Removes shadows from chat bubbles and other inputs to clean up the interface
- Aligns chart and chart tooltip colors with color mode

<img width="1440" alt="Screenshot 2025-02-28 at 3 11 12 PM" src="https://github.com/user-attachments/assets/9d99580e-f709-4a89-b16a-996bc11a8db6" />

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/eaf13db3-63bf-4dfe-9d2b-2cc4d8b846e7" />

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/b094d058-86b3-43c1-ba11-f99c2d1c6b48" />

cc @01painadam