### PR TITLE
Add widget title bars

### DIFF
--- a/src/components/ReportContentWidget.jsx
+++ b/src/components/ReportContentWidget.jsx
@@ -1,7 +1,7 @@
 // Report Widget for Monitoring App
 // Renders different Widgets Based on selected insights
 
-import { Box, Button } from "@chakra-ui/react";
+import { Box, Button, Flex, Heading } from "@chakra-ui/react";
 import TextWidget from "./insights/TextWidget";
 import TableWidget from "./insights/TableWidget";
 import ChartWidget from "./insights/BarChartWidget";
@@ -42,7 +42,6 @@ export default function ReportContentWidget(data) {
       gridColumn="2"
       gridRow="2 / -1"
       mb="4"
-      p="12"
       h="100%"
       borderRadius="lg"
       bg="bg"
@@ -51,18 +50,18 @@ export default function ReportContentWidget(data) {
       justifySelf="stretch"
       overflowY="scroll"
     >
-      <Button
-        position="absolute"
-        top="10px"
-        right="10px"
-        aria-label="Remove from report"
-        size="xs"
-        variant="ghost"
-        onClick={() => deleteFromReport(data.title)}
-      >
-        <CollecticonTrashBin />
-        Remove from report
-      </Button>
+      <Flex p="6" pb="0" gap="4" alignItems="center" justifyContent="space-between">
+        <Heading size="sm" m="0" as="h4">{data.title}</Heading>
+        <Button
+          aria-label="Remove from report"
+          size="xs"
+          variant="ghost"
+          onClick={() => deleteFromReport(data.title)}
+        >
+          <CollecticonTrashBin />
+          Remove from report
+        </Button>
+      </Flex>
       <WidgetComponent {...data} />
     </Box>
   );

--- a/src/components/SidePanelWidget.jsx
+++ b/src/components/SidePanelWidget.jsx
@@ -10,6 +10,7 @@ import ChartWidget from "./insights/BarChartWidget";
 import TimeSeriesWidget from "./insights/TimeSeriesWidget";
 import MapWidget from "./insights/MapWidget";
 import { CloseButton } from "./ui/close-button";
+import { CollecticonClipboardTick } from "@devseed-ui/collecticons-react";
 
 export default function SidePanelWidget() {
   const [sidePanelContent, setSidePanelContent] = useAtom(sidePanelContentAtom);
@@ -46,11 +47,12 @@ export default function SidePanelWidget() {
 
   return (
     <Box position="relative" gridColumn="2" gridRow="2 / -1" my="4" mb="1" borderRadius="lg" border="1px solid" borderColor="border" bg="bg.subtle" justifySelf="stretch" overflowY="scroll">
-      <Flex py="2" px="6" gap="4" alignItems="center" bg="bg.muted" borderBottomWidth="1px" borderColor="border">
-        <Heading size="md" m="0" as="h4">{sidePanelContent.title}</Heading>
+      <Flex py="2" px="6" gap="4" alignItems="center" bg={isInReport ? "blue.subtle" : "bg.muted"} borderBottomWidth="1px" borderColor="border">
+        {isInReport && <CollecticonClipboardTick color="var(--chakra-colors-blue-fg)" />}
+        <Heading size="sm" m="0" as="h4">{sidePanelContent.title}</Heading>
         {
           isInReport
-            ? <Button size="xs" colorPalette="red" textTransform="uppercase" variant="surface" onClick={() => deleteFromReport(sidePanelContent.title)}>Remove From Report</Button>
+            ? <Button size="xs" colorPalette="blue" textTransform="uppercase" variant="outline" onClick={() => deleteFromReport(sidePanelContent.title)}>Remove From Report</Button>
             : <Button size="xs" colorPalette="blue" textTransform="uppercase" variant="surface" onClick={() => addToReport(sidePanelContent)}>Add To Report</Button>
         }
         <CloseButton size="xs" ml="auto" onClick={() => setSidePanelContent(null)} />

--- a/src/components/SidePanelWidget.jsx
+++ b/src/components/SidePanelWidget.jsx
@@ -1,7 +1,7 @@
 // Side Panel for Monitoring App
 // Renders different Widgets Based on selected insights
 
-import { Box, Button, ButtonGroup, IconButton } from "@chakra-ui/react";
+import { Box, Button, Flex, Heading } from "@chakra-ui/react";
 import { sidePanelContentAtom, addToReportAtom, deleteFromReportAtom } from "../atoms";
 import TextWidget from "./insights/TextWidget";
 import TableWidget from "./insights/TableWidget";
@@ -9,7 +9,7 @@ import { useAtom } from "jotai";
 import ChartWidget from "./insights/BarChartWidget";
 import TimeSeriesWidget from "./insights/TimeSeriesWidget";
 import MapWidget from "./insights/MapWidget";
-import { CgClose } from "react-icons/cg";
+import { CloseButton } from "./ui/close-button";
 
 export default function SidePanelWidget() {
   const [sidePanelContent, setSidePanelContent] = useAtom(sidePanelContentAtom);
@@ -45,26 +45,16 @@ export default function SidePanelWidget() {
   const isInReport = reportContent.some((item) => item.title === sidePanelContent.title);
 
   return (
-    <Box position="relative" gridColumn="2" gridRow="2 / -1" my="4" mb="1" p="12" borderRadius="lg" border="1px solid" borderColor="border" bg="bg.subtle" justifySelf="stretch" overflowY="scroll">
-      <ButtonGroup
-        position="absolute"
-        top="10px"
-        right="10px"
-        size="xs"
-      >
+    <Box position="relative" gridColumn="2" gridRow="2 / -1" my="4" mb="1" borderRadius="lg" border="1px solid" borderColor="border" bg="bg.subtle" justifySelf="stretch" overflowY="scroll">
+      <Flex py="2" px="6" gap="4" alignItems="center" bg="bg.muted" borderBottomWidth="1px" borderColor="border">
+        <Heading size="md" m="0" as="h4">{sidePanelContent.title}</Heading>
         {
           isInReport
-            ? <Button colorPalette="red" textTransform="uppercase" variant="surface" onClick={() => deleteFromReport(sidePanelContent.title)}>Remove From Report</Button>
-            : <Button colorPalette="blue" textTransform="uppercase" variant="surface" onClick={() => addToReport(sidePanelContent)}>Add To Report</Button>
+            ? <Button size="xs" colorPalette="red" textTransform="uppercase" variant="surface" onClick={() => deleteFromReport(sidePanelContent.title)}>Remove From Report</Button>
+            : <Button size="xs" colorPalette="blue" textTransform="uppercase" variant="surface" onClick={() => addToReport(sidePanelContent)}>Add To Report</Button>
         }
-        <IconButton
-          aria-label="Close panel"
-          variant="ghost"
-          onClick={() => setSidePanelContent(null)}
-        >
-          <CgClose />
-        </IconButton>
-      </ButtonGroup>
+        <CloseButton size="xs" ml="auto" onClick={() => setSidePanelContent(null)} />
+      </Flex>
       <WidgetComponent {...sidePanelContent} />
     </Box>
   );

--- a/src/components/SidePanelWidget.jsx
+++ b/src/components/SidePanelWidget.jsx
@@ -47,13 +47,13 @@ export default function SidePanelWidget() {
 
   return (
     <Box position="relative" gridColumn="2" gridRow="2 / -1" my="4" mb="1" borderRadius="lg" border="1px solid" borderColor="border" bg="bg.subtle" justifySelf="stretch" overflowY="scroll">
-      <Flex py="2" px="6" gap="4" alignItems="center" bg={isInReport ? "blue.subtle" : "bg.muted"} borderBottomWidth="1px" borderColor="border">
+      <Flex py="2" px="6" gap="2" alignItems="center" bg={isInReport ? "blue.subtle" : "bg.muted"} borderBottomWidth="1px" borderColor="border">
         {isInReport && <CollecticonClipboardTick color="var(--chakra-colors-blue-fg)" />}
         <Heading size="sm" m="0" as="h4">{sidePanelContent.title}</Heading>
         {
           isInReport
-            ? <Button size="xs" colorPalette="blue" textTransform="uppercase" variant="outline" onClick={() => deleteFromReport(sidePanelContent.title)}>Remove From Report</Button>
-            : <Button size="xs" colorPalette="blue" textTransform="uppercase" variant="surface" onClick={() => addToReport(sidePanelContent)}>Add To Report</Button>
+            ? <Button size="xs" ml="2" colorPalette="blue" textTransform="uppercase" variant="outline" onClick={() => deleteFromReport(sidePanelContent.title)}>Remove From Report</Button>
+            : <Button size="xs" ml="2" colorPalette="blue" textTransform="uppercase" variant="solid" onClick={() => addToReport(sidePanelContent)}>Add To Report</Button>
         }
         <CloseButton size="xs" ml="auto" onClick={() => setSidePanelContent(null)} />
       </Flex>

--- a/src/components/insights/BarChartWidget.jsx
+++ b/src/components/insights/BarChartWidget.jsx
@@ -1,10 +1,10 @@
 import { useEffect, useRef, useState } from "react";
 import * as d3 from "d3";
 import T from "prop-types";
-import { Box, Heading, Text, IconButton } from "@chakra-ui/react";
+import { Box, Text, IconButton } from "@chakra-ui/react";
 import { FaChartBar, FaChartPie } from "react-icons/fa";
 
-export default function ChartWidget({ data, title, description }) {
+export default function ChartWidget({ data, description }) {
   const chartRef = useRef();
   const containerRef = useRef();
   const tooltipRef = useRef();
@@ -117,8 +117,7 @@ export default function ChartWidget({ data, title, description }) {
   }, [data, chartType]);
 
   return (
-    <Box ref={containerRef} style={{ position: "relative" }} padding="0">
-      <Heading>{title}</Heading>
+    <Box ref={containerRef} style={{ position: "relative" }} p="6">
       <IconButton
         onClick={() => setChartType(chartType === "bar" ? "pie" : "bar")}
         aria-label="Toggle Chart Type"
@@ -127,7 +126,7 @@ export default function ChartWidget({ data, title, description }) {
         variant="surface"
         size="xs"
       >
-        Toggle {chartType === "bar" ? <FaChartPie /> : <FaChartBar />}
+        Toggle Chart Type {chartType === "bar" ? <FaChartPie /> : <FaChartBar />}
       </IconButton>
       <svg ref={chartRef} width={500} height={500} />
       <div ref={tooltipRef} />
@@ -141,6 +140,5 @@ ChartWidget.propTypes = {
     categories: T.arrayOf(T.string).isRequired,
     values: T.arrayOf(T.number).isRequired,
   }).isRequired,
-  title: T.string,
   description: T.string,
 };

--- a/src/components/insights/MapWidget.jsx
+++ b/src/components/insights/MapWidget.jsx
@@ -28,7 +28,7 @@ export default function MapWidget({ data, description }) {
   return (
     <Box
       position="relative"
-      height="calc(100% - 3rem)"
+      height="calc(100% - 3.125rem)"
       p="6"
       css={{
         _dark: {

--- a/src/components/insights/MapWidget.jsx
+++ b/src/components/insights/MapWidget.jsx
@@ -1,11 +1,11 @@
 import T from "prop-types";
-import { Box, Heading, Text } from "@chakra-ui/react";
+import { Box, Text } from "@chakra-ui/react";
 import MapGl, { Layer, Source, AttributionControl, NavigationControl } from "react-map-gl/maplibre";
 import "maplibre-gl/dist/maplibre-gl.css";
 import bbox from "@turf/bbox";
 import { useColorModeValue } from "../ui/color-mode";
 
-export default function MapWidget({ data, title, description }) {
+export default function MapWidget({ data, description }) {
   let viewState = {
     longitude: 0,
     latitude: 0,
@@ -28,7 +28,8 @@ export default function MapWidget({ data, title, description }) {
   return (
     <Box
       position="relative"
-      height="100%"
+      height="calc(100% - 3rem)"
+      p="6"
       css={{
         _dark: {
           "& .maplibregl-ctrl-scale": {
@@ -59,10 +60,9 @@ export default function MapWidget({ data, title, description }) {
         },
       }}
     >
-      <Heading mb={4}>{title}</Heading>
       <MapGl
         initialViewState={viewState}
-        style={{ width: "100%", height: "calc(100% - 2.75rem)" }}
+        style={{ width: "100%", height: "100%" }}
         attributionControl={false}
       >
         <Source
@@ -106,6 +106,5 @@ export default function MapWidget({ data, title, description }) {
 
 MapWidget.propTypes = {
   data: T.object,
-  title: T.string,
   description: T.string
 };

--- a/src/components/insights/TableWidget.jsx
+++ b/src/components/insights/TableWidget.jsx
@@ -1,15 +1,14 @@
 
 
 import T from "prop-types";
-import { Box, Heading, Table, Text } from "@chakra-ui/react";
+import { Box, Table, Text } from "@chakra-ui/react";
 
 /**
  * Data is an array of objects
  */
-export default function TableWidget({ title, data, description }) {
+export default function TableWidget({ data, description }) {
   return (
-    <Box>
-      <Heading>{title}</Heading>
+    <Box p="6">
       <Table.Root variant="line">
         <Table.Header>
           <Table.Row>
@@ -33,7 +32,6 @@ export default function TableWidget({ title, data, description }) {
 
 TableWidget.propTypes = {
   data: T.string.isRequired,
-  title: T.string,
   description: T.string,
 };
 

--- a/src/components/insights/TextWidget.jsx
+++ b/src/components/insights/TextWidget.jsx
@@ -1,10 +1,13 @@
-
-
+import { Box} from "@chakra-ui/react";
 import Markdown from "react-markdown";
 import T from "prop-types";
 
 export default function TextWidget({ data }) {
-  return <Markdown>{data}</Markdown>;
+  return (
+    <Box p="6">
+      <Markdown>{data}</Markdown>
+    </Box>
+  );
 }
 
 TextWidget.propTypes = {

--- a/src/components/insights/TimeSeriesWidget.jsx
+++ b/src/components/insights/TimeSeriesWidget.jsx
@@ -101,8 +101,7 @@ export default function TimeSeriesWidget(data) {
   }, [data, colors]);
 
   return (
-    <Box ref={containerRef} position="relative">
-      <Text fontSize="lg" fontWeight="bold">{data.title}</Text>
+    <Box ref={containerRef} position="relative" p="6">
       <svg ref={chartRef} />
       <div ref={tooltipRef} />
       <Flex wrap="wrap" mt={2}>

--- a/src/components/insights/WidgetButton.jsx
+++ b/src/components/insights/WidgetButton.jsx
@@ -1,6 +1,6 @@
 import { ButtonGroup, Button, IconButton, Text } from "@chakra-ui/react";
 import { Tooltip } from "../ui/tooltip";
-import { sidePanelContentAtom } from "../../atoms";
+import { sidePanelContentAtom, addToReportAtom } from "../../atoms";
 import { useAtom } from "jotai";
 import T from "prop-types";
 import { CollecticonChartBars, CollecticonChartLine, CollecticonMap, CollecticonTable, CollecticonTextBlock } from "@devseed-ui/collecticons-react";
@@ -17,6 +17,7 @@ const iconMap = {
 export default function WidgetButton({ data }) {
   const { title, type, chart_type } = data;
   const [, setSidePanelContent] = useAtom(sidePanelContentAtom);
+  const [reportContent] = useAtom(addToReportAtom);
 
   let IconComponent = CollecticonTextBlock;
 
@@ -25,25 +26,26 @@ export default function WidgetButton({ data }) {
   } else if (iconMap[type]) {
     IconComponent = iconMap[type];
   }
-
+  const isInReport = reportContent.some((item) => item.title === title);
   return (
     <Tooltip content={title} showArrow>
       <ButtonGroup
         w="full"
-        size="sm"
         attached
         _groupHover={{ colorPalette: "blue" }}
+        size="xl"
         onClick={() => {
           setSidePanelContent(data);
         }}
       >
-        <IconButton variant="solid" size="xl" bg="gray.500">
+        <IconButton color="white" bg={isInReport ? "blue.900" : "gray.500"}>
           <IconComponent />
         </IconButton>
-        <Button variant="outline" py="6" flex="1" justifyContent="start">
+        <Button variant="outline" flex="1" justifyContent="start" borderColor={isInReport && "blue.900"}>
           <Text
             isTruncated
             fontWeight="bold"
+            fontSize="sm"
             noOfLines={1}
             whiteSpace="nowrap"
             overflow="hidden"


### PR DESCRIPTION
Builds off of `feature/map-insights` to add the widget title bars included in the designs by Fausto.

https://github.com/user-attachments/assets/6257289c-8731-43dd-ab40-0b337b41d49c

Noting that adding KBAs to report still results in a crash.

~I've started mocking the interaction and components for "View all insights" but think that there needs to be an "all insights" atom added to keep all of the returned insights in one store...~ Edit - added this in the next pr

@kamicut this is based on your branch; I didn't want to make too many additional changes on top of my map insights widget style change.