### PR TITLE
Responsive insight charts

### DIFF
--- a/src/components/LclLogo.jsx
+++ b/src/components/LclLogo.jsx
@@ -1,6 +1,6 @@
 import T from "prop-types";
 
-function LclLogo({ width = "14", fill = "currentColor", avatarOnly }) {
+function LclLogo({ width = 14, fill = "currentColor", avatarOnly }) {
   if (avatarOnly) {
     return (
       <svg

--- a/src/components/MessageOut/wrapper.jsx
+++ b/src/components/MessageOut/wrapper.jsx
@@ -6,7 +6,7 @@ function MessageOutWrapper({ children }) {
   return (
     <Box mb="4" p="2" bgColor="bg.muted" borderRadius="md" borderWidth={1} borderColor="border" flexGrow="1" overflow="hidden">
       <Box float="left" mr="1" mt="0.5">
-        <LclLogo width="12" avatarOnly fill="var(--chakra-colors-bg-inverted)" float="left" />
+        <LclLogo width={12} avatarOnly fill="var(--chakra-colors-bg-inverted)" float="left" />
       </Box>
       {children}
     </Box>

--- a/src/components/SidePanelWidget.jsx
+++ b/src/components/SidePanelWidget.jsx
@@ -75,6 +75,7 @@ export default function SidePanelWidget() {
         borderColor="border"
         position="sticky"
         top="0"
+        zIndex="1000"
       >
         {isInReport && (
           <CollecticonClipboardTick color="var(--chakra-colors-blue-fg)" />

--- a/src/components/globalheader.jsx
+++ b/src/components/globalheader.jsx
@@ -37,7 +37,7 @@ function GlobalHeader() {
       justifyContent="space-between"
     >
       <Flex gap={12} alignItems="center">
-        <LclLogo width="80" />
+        <LclLogo width={80} />
         <Text
           fontFamily="mono"
           fontVariantNumeric="slashed-zero"
@@ -94,7 +94,7 @@ function GlobalHeader() {
       <Flex gap={12} alignItems="center">
         <ColorModeButton />
         <a href="https://www.bezosearthfund.org/" target="_blank" rel="noreferrer" title="Bezos Earth Fund Logo">
-          <BEFLogo width="92" />
+          <BEFLogo width={92} />
         </a>
         <a href="https://www.wri.org/" target="_blank" rel="noreferrer" title="WRI Logo">
           <Image src={WRILogo} alt="WRI Logo" width="120px" css={{ _dark: { filter: "invert(1) saturate(0) brightness(6)" }}} />

--- a/src/routes/monitoring.jsx
+++ b/src/routes/monitoring.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { createFileRoute } from "@tanstack/react-router";
 import { Box, Collapsible, Grid, Heading, List } from "@chakra-ui/react";
 import Providers from "../Providers";
@@ -15,6 +15,12 @@ function Monitoring() {
   const [isReportOpen, setIsReportOpen] = useState(false);
   const [reportContent] = useAtom(reportContentAtom);
   const [sidePanelContent] = useAtom(sidePanelContentAtom);
+  useEffect(() => {
+    if(reportContent.length === 0){
+      setIsReportOpen(false);
+    }
+  }, [reportContent]);
+  
   const panelBg = useColorModeValue("bg.panel", "bg.emphasized");
   return (
     <Providers>
@@ -25,7 +31,7 @@ function Monitoring() {
         bg="bg"
       >
         <GlobalHeader />
-        <Grid templateColumns="1fr" templateRows="1fr" p="4" pt="0" gap="2">
+        <Grid templateColumns="1fr" templateRows="1fr" autoColumns={isReportOpen ? "minmax(0px, 2fr)" : "3.5rem"} p="4" pt="0" gap="2">
           <Grid
             gap="4"
             autoColumns="minmax(0px, 2fr)"


### PR DESCRIPTION
Makes sidepanel and report widget charts responsive, following the same pattern from the `BarChart` component. Also handles some of the Report/Sidepanel expand<>contract state issues when the report was empty.

![image](https://github.com/user-attachments/assets/71984cca-2fce-45cb-b28c-9952abcc4949)
