### PR TITLE
switch api to use non-dev instance

### DIFF
--- a/src/atoms.js
+++ b/src/atoms.js
@@ -40,8 +40,8 @@ function makeInputMessage(query) {
 }
 
 const appURLs = {
-  "alerting": "https://dev.api.zeno.ds.io/stream/dist_alert",
-  "monitoring": "https://dev.api.zeno.ds.io/stream/kba"
+  "alerting": "https://api.zeno.ds.io/stream/dist_alert",
+  "monitoring": "https://api.zeno.ds.io/stream/kba"
 };
 
 export const addInsightsAtom = atom((get) => get(insightsAtom), (get, set, insights) => {


### PR DESCRIPTION
This removes references to the dev api and uses the main api for the frontend. 